### PR TITLE
Feature/unpublish resources from s3 cv19 62

### DIFF
--- a/core/test/test_utils.py
+++ b/core/test/test_utils.py
@@ -102,7 +102,7 @@ class TestUtilsS3Upload(MethodsTestCase):
         Get objects from s3 bucket (mocked,  presumably) and replicate structure
         implied in key names as directory tree with root in local_dir.
         """
-        bucket_keys = (object["Key"] for object in self.s3_client.list_objects(Bucket=self.mock_bucket)["Contents"])
+        bucket_keys = (s3_obj["Key"] for s3_obj in self.s3_client.list_objects(Bucket=self.mock_bucket)["Contents"])
         for s3_key in bucket_keys:
             # split s3_key into directory-like component and filename-like component
             path, filename = os.path.split(s3_key)

--- a/core/utils.py
+++ b/core/utils.py
@@ -1,3 +1,4 @@
+import glob
 import pyclamd
 
 import boto3
@@ -5,8 +6,7 @@ import boto3
 from django.core.management import call_command
 from django.conf import settings
 
-from os import listdir
-from os.path import isfile, join, splitext
+from os.path import isfile, join, relpath, splitext
 
 from wagtail.core.signals import page_published, page_unpublished
 
@@ -112,40 +112,49 @@ def export_directory(path:str=''):
     Crawl through directory structure found at settings.BUILD_DIR/path. Upload
     files and directories with contents only to AWS s3 (no empty dirs permitted in s3!)
     """
+    # get list of dicts with relative and absolute paths for each html files to upload
     directory_path = join(settings.BUILD_DIR, path)
-    directory_contents = listdir(directory_path)
+    html_files_in_directory = glob.glob(f"{directory_path}/**/*.html", recursive=True)
+    files_2_upload = [ {"Filename": f, "Key": relpath(f, start=directory_path)} for f in html_files_in_directory]
+
+    # get S3 keys only as set
+    s3_keys_2_upload = { f["Key"] for f in files_2_upload }
+
     s3_client = boto3.client(
         "s3",
         region_name = settings.AWS_REGION_DEPLOYMENT,
         aws_access_key_id = settings.AWS_ACCESS_KEY_ID_DEPLOYMENT,
         aws_secret_access_key = settings.AWS_SECRET_ACCESS_KEY_DEPLOYMENT
     )
-    for f in directory_contents:
 
-        # ignore the whole static directory and any non-html files
-        if f == 'static':
+    # get complete set of bucket keys
+    paginator = s3_client.get_paginator('list_objects')
+    page_iterator = paginator.paginate(Bucket=settings.AWS_STORAGE_BUCKET_NAME_DEPLOYMENT)
+    bucket_keys = set()
+    for page in page_iterator:
+        try:
+            page_files = {s3_obj["Key"] for s3_obj in page["Contents"]}
+            bucket_keys.update(page_files)
+        except KeyError:
             continue
 
-        # construct relative filepaths
-        full_filepath = join(directory_path , f)
-        local_filepath = join(path, f)
+    # get diff of bucket vs uploaded s3 keys
+    bucket_keys_2_remove = bucket_keys.difference(s3_keys_2_upload)
 
-        # upload files...
-        if isfile(full_filepath):
+    # upload whats being uploaded
+    for f in files_2_upload:
+        s3_client.upload_file(
+            Filename=f["Filename"],
+            Bucket=settings.AWS_STORAGE_BUCKET_NAME_DEPLOYMENT,
+            Key=f["Key"]
+        )
 
-            # ... but ONLY html files!
-            if splitext(full_filepath)[1] != '.html':
-                continue
-
-            s3_client.upload_file(
-                Filename=full_filepath,
-                Bucket=settings.AWS_STORAGE_BUCKET_NAME_DEPLOYMENT,
-                Key=local_filepath
-            )
-        # recursively deal with directories
-        else:
-            export_directory(local_filepath)
-
+    # remove whats being removed
+    for key in bucket_keys_2_remove:
+        s3_client.delete_object(
+            Bucket=settings.AWS_STORAGE_BUCKET_NAME_DEPLOYMENT,
+            Key=key
+        )
 
 page_published.connect(prerender_pages)
 page_unpublished.connect(prerender_pages)


### PR DESCRIPTION
### What

Added 'unpublishing' feature for html files ONLY - any html files found in S3 bucket but NOT found in settings.BUILD_DIR will be removed from S3. Non-html files are untouched. 

Assumptions:
- all html files will .html extension (rather than .htm)

### How to review

Read the code in core.utils, run the tests in core.tests.test_utils

Describe the steps required to test the changes.
Unit tests:
Unit tests for this feature are in core/test/test_utils/TestUtilsS3Upload. The helper script ./bin/test should find it and run it.

Live tests:

add some images, css etc to a bucket you can access

set the following env vars to point at the bucket then run the server:
AWS_ACCESS_KEY_ID_DEPLOYMENT
AWS_SECRET_ACCESS_KEY_DEPLOYMENT
AWS_STORAGE_BUCKET_NAME_DEPLOYMENT
AWS_REGION_DEPLOYMENT

make some pages in wagtail and hit publish

the server logs should tell you its trying to upload the site to AWS_STORAGE_BUCKET_NAME_DEPLOYMENT

you should see the html files and directory structure for the site in your s3 bucket! You should also still see the images and other stuff you added manually.

Delete some pages in wagtail and hit publish

You should see the html you removed gone from s3, but the images and other stuff should still be there.


