### PR TITLE
completely remove download button if no download is available

### DIFF
--- a/CMS/templates/contentPages/resource_item_page.html
+++ b/CMS/templates/contentPages/resource_item_page.html
@@ -29,7 +29,7 @@
                                         <div class="download-button-wrapper">
                                             {% if page.upload_link %}
                                                 <a class="download-button" href="{{ page.upload_link }}">Download</a>
-                                            {% else %}
+                                            {% elif page.link_document %}
                                                 {% convert_s3_link page.link_document.url as link_document_url %}
                                                 <a class="download-button" href="{{ link_document_url }}">Download</a>
                                             {% endif %}


### PR DESCRIPTION
### What

I've completely removed the download button on the resource item page if no download is available. This is because they use resources just as a text placeholder to store links etc

### How to review

