### PR TITLE
reenable the document picker on the resource item page

### DIFF
--- a/CMS/static/js/main.js
+++ b/CMS/static/js/main.js
@@ -1,5 +1,5 @@
 (function($) {
-  var SUBSCRIPTION_URL = {{url_address}};
+  var SUBSCRIPTION_URL = "{{url_address}}";
 
   var NewTabLink = function(link) {
     this.link = link;

--- a/contentPages/models.py
+++ b/contentPages/models.py
@@ -263,7 +263,7 @@ class ResourceItemPage(MethodsBasePage):
             FieldPanel('heading'),
             FieldPanel('description'),
             FieldPanel('upload_link'),
-            # DocumentChooserPanel('link_document'),
+            DocumentChooserPanel('link_document'),
             ImageChooserPanel('preview_image'),
             FieldPanel('preview_image_screen_reader_text'),
         ], heading='Header section'),


### PR DESCRIPTION
### What

Add the document picker panel back to the resource item page editor.

### How to review

In the CMS go the editor screen for a resource item page.
You should have the option to select the uploaded document you want to link to.
