### PR TITLE
Hotfix/reorder resources

### DIFF
--- a/contentPages/models.py
+++ b/contentPages/models.py
@@ -217,7 +217,7 @@ class ResourcesPage(MethodsBasePage):
 
     @property
     def resource_list(self):
-        return ResourceItemPage.objects.live().descendant_of(self)
+        return ResourceItemPage.objects.live().descendant_of(self).order_by('-last_published_at')
 
     @property
     def campaign_slug(self):


### PR DESCRIPTION
### What

Set order by for the resources list to show latest publication first

### How to review

Look at the order of resources on the resource index page.
Republish the resource at the bottom of the list.
Check the index page again and the resource you republished should now be at the top of the list.
