### PR TITLE
add max in-memory size of 2.5MB for s3 uploads to avoid eating system…

### DIFF
--- a/CMS/settings/production.py
+++ b/CMS/settings/production.py
@@ -30,7 +30,7 @@ AWS_ACCESS_KEY_ID = os.environ.get('AWS_ACCESS_KEY_ID')
 AWS_SECRET_ACCESS_KEY = os.environ.get('AWS_SECRET_ACCESS_KEY')
 AWS_STORAGE_BUCKET_NAME = os.environ.get('AWS_STORAGE_BUCKET_NAME')
 # max in-memory size for s3 uploads. Anything bigger than this rolled over into a temp file.
-AWS_S3_MAX_MEMORY_SIZE = int(2.5 * 1000000) # 2.5MB
+AWS_S3_MAX_MEMORY_SIZE = os.environ.get('AWS_S3_MAX_MEMORY_SIZE', int(2.5 * 1000000)) # default 2.5MB
 
 # Site deployment settings
 

--- a/CMS/settings/production.py
+++ b/CMS/settings/production.py
@@ -29,6 +29,8 @@ DEFAULT_FILE_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
 AWS_ACCESS_KEY_ID = os.environ.get('AWS_ACCESS_KEY_ID')
 AWS_SECRET_ACCESS_KEY = os.environ.get('AWS_SECRET_ACCESS_KEY')
 AWS_STORAGE_BUCKET_NAME = os.environ.get('AWS_STORAGE_BUCKET_NAME')
+# max in-memory size for s3 uploads. Anything bigger than this rolled over into a temp file.
+AWS_S3_MAX_MEMORY_SIZE = int(2.5 * 1000000) # 2.5MB
 
 # Site deployment settings
 


### PR DESCRIPTION
… memory

### What

Currently this setting was default for the django s3 file storage package we're using (from https://django-storages.readthedocs.io/en/latest/backends/amazon-S3.html):

```
AWS_S3_MAX_MEMORY_SIZE (optional; default is 0 - do not roll over)
The maximum amount of memory (in bytes) a file can take up before being rolled over into a temporary file on disk.
```

This means, I think, that all files are being read into memory before upload to s3, rather than dumped into a temp file. For large files this may cause issues with container memory. 

Set to 2.5MB here as that is what the other file upload systems in django default to - whether or not that is appropriate for us might require some discussion. 

### How to review

Attempt an upload to a bucket you can view, and see if it is successful?
