### PR TITLE
Revert "Feature/logging"

### DIFF
--- a/CMS/settings/production.py
+++ b/CMS/settings/production.py
@@ -1,14 +1,40 @@
 import sys, logging, watchtower
 
-from boto3.session import Session
-
 from .base import *
 
 
 DEBUG = False
 SECRET_KEY = os.environ.get('SECRET_KEY')
 
+# ALLOWED_HOSTS = [
+#     "dev-covid19-248806762.eu-west-1.elb.amazonaws.com",
+#     "localhost"
+# ]
 ALLOWED_HOSTS = ['*']
+
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'handlers': {
+        'file': {
+            'level': 'DEBUG',
+            'class': 'logging.FileHandler',
+            'filename': './debug.log',
+        },
+        'console': {
+            'level': 'DEBUG',
+            'class': 'logging.StreamHandler',
+            'stream': sys.stdout
+        }
+    },
+    'loggers': {
+        'django': {
+            'handlers': ['file', 'console'],
+            'level': 'DEBUG',
+            'propagate': True,
+        },
+    },
+}
 
 WAGTAILFRONTENDCACHE = {
     'cloudfront': {
@@ -49,52 +75,9 @@ SECURE_CONTENT_TYPE_NOSNIFF = True
 
 SECURE_BROWSER_XSS_FILTER = True
 
-SESSION_COOKIE_SECURE = True
+# SESSION_COOKIE_SECURE = True
 
-CSRF_COOKIE_SECURE = True
-
-# Logging
-
-boto3_session = Session(aws_access_key_id=AWS_ACCESS_KEY_ID,
-                        aws_secret_access_key=AWS_SECRET_ACCESS_KEY,
-                        region_name=AWS_REGION_DEPLOYMENT)
-
-LOGGING = {
-    'version': 1,
-    'disable_existing_loggers': False,
-    'root': {
-        'level': logging.ERROR,
-        'handlers': ['console'],
-    },
-    'formatters': {
-        'simple': {
-            'format': u"%(asctime)s [%(levelname)-8s] %(message)s",
-            'datefmt': "%Y-%m-%d %H:%M:%S"
-        },
-        'aws': {
-            'format': u"%(asctime)s [%(levelname)-8s] %(message)s",
-            'datefmt': "%Y-%m-%d %H:%M:%S"
-        },
-    },
-    'handlers': {
-        'watchtower': {
-            'level': 'DEBUG',
-            'class': 'watchtower.CloudWatchLogHandler',
-                     'boto3_session': boto3_session,
-                     'log_group': 'PHECovidResourcesLogs',
-                     'stream_name': FINAL_SITE_DOMAIN + 'Stream',
-            'formatter': 'aws',
-        }
-    },
-    'loggers': {
-        'django': {
-            'level': 'INFO',
-            'handlers': ['watchtower'],
-            'propagate': True,
-        },
-    },
-}
-
+# CSRF_COOKIE_SECURE = True
 
 
 try:


### PR DESCRIPTION
Reverts methods/phe-cv19-site#48

As we now have logs coming out of the instances, this change is not required.
(and is currently breaking)