### PR TITLE
wagtail already contains custom ordering code - remove order_by line

### DIFF
--- a/contentPages/models.py
+++ b/contentPages/models.py
@@ -217,7 +217,7 @@ class ResourcesPage(MethodsBasePage):
 
     @property
     def resource_list(self):
-        return ResourceItemPage.objects.live().descendant_of(self).order_by('-last_published_at')
+        return ResourceItemPage.objects.live().descendant_of(self)
 
     @property
     def campaign_slug(self):


### PR DESCRIPTION
### What

Removed order_by line so that users can reorder items within the wagtail editor

### How to review

