### PR TITLE
Fix issue with compilescss

### DIFF
--- a/CMS/settings/base.py
+++ b/CMS/settings/base.py
@@ -91,6 +91,7 @@ TEMPLATES = [
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
         'DIRS': [
             os.path.join(PROJECT_DIR, 'templates'),
+            os.path.join(PROJECT_DIR, 'CMS/templates'),
         ],
         'APP_DIRS': True,
         'OPTIONS': {

--- a/CMS/templates/contentPages/home_page.html
+++ b/CMS/templates/contentPages/home_page.html
@@ -1,4 +1,4 @@
-{% extends "../base.html" %}
+{% extends 'base.html' %}
 {% load wagtailcore_tags wagtailimages_tags sass_tags methods_tags %}
 
 {#{% block extra_css %}#}

--- a/CMS/templates/contentPages/landing_page.html
+++ b/CMS/templates/contentPages/landing_page.html
@@ -1,4 +1,4 @@
-{% extends "../base.html" %}
+{% extends "base.html" %}
 {% load wagtailcore_tags wagtailimages_tags sass_tags methods_tags %}
 
 {% block content %}

--- a/CMS/templates/contentPages/overview_page.html
+++ b/CMS/templates/contentPages/overview_page.html
@@ -1,4 +1,4 @@
-{% extends "../base.html" %}
+{% extends "base.html" %}
 {% load wagtailcore_tags wagtailimages_tags sass_tags methods_tags %}
 
 {% block content %}

--- a/CMS/templates/contentPages/resource_item_page.html
+++ b/CMS/templates/contentPages/resource_item_page.html
@@ -1,4 +1,4 @@
-{% extends "../base.html" %}
+{% extends "base.html" %}
 {% load wagtailcore_tags wagtailimages_tags sass_tags  methods_tags %}
 
 {% block content %}

--- a/CMS/templates/contentPages/resources_page.html
+++ b/CMS/templates/contentPages/resources_page.html
@@ -1,4 +1,4 @@
-{% extends "../base.html" %}
+{% extends "base.html" %}
 {% load wagtailcore_tags wagtailimages_tags sass_tags methods_tags %}
 
 {% block content %}


### PR DESCRIPTION
### What
compilescss was throwing errors for all content pages. It seems that while the django templating engine can cope with relative paths for include and extend statements i.e. `{% extends '../base.html'%}` other commands cannot

This PR registers CMS/templates as a templates directory in base.py. It then uses  `{% extends 'base.html'%}` without the relative reference for include and extends template syntax

### How to review
Run `python manage.py compilescss` in the dev terminal.
Pull this code
Run again
Compare output
Check css is still as expected on the site
