### PR TITLE
upgrade the wagtail version to 2.8.1 (current latest)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Django<2.3,>=2.2.2
-wagtail==2.6
+wagtail==2.8.1
 psycopg2-binary
 flake8==3.7.7
 coverage==4.5.1


### PR DESCRIPTION
### What

Upgraded the version of Wagtail due to potential security issue.

### How to review

Run the CMS locally and go through testing all the CMS functionality.
