### PR TITLE
only show live pages

### DIFF
--- a/contentPages/models.py
+++ b/contentPages/models.py
@@ -430,7 +430,7 @@ class AssetTypePage(MethodsBasePage):
     ]
 
     def resource_item_pages(self):
-        return ResourceItemPage.objects.filter(document_type=self.document_type)
+        return ResourceItemPage.objects.live().filter(document_type=self.document_type)
 
     def asset_count(self):
         resource_count = len(ResourceItemPage.objects.filter(document_type=self.document_type))


### PR DESCRIPTION
### What

Only live asset pages will be displayed when a user selects an asset type tile. 

### How to review


