### PR TITLE
Feature/campaign name on resource and add s to asset types

### DIFF
--- a/CMS/enums.py
+++ b/CMS/enums.py
@@ -7,9 +7,9 @@ class Enums:
     languages = Languages()
 
     asset_types = (
-        ('posters', 'Poster'),
-        ('digital_screens', 'Digital Screen'),
-        ('alternative_formats', 'Alternative Format'),
+        ('posters', 'Posters'),
+        ('digital_screens', 'Digital Screens'),
+        ('alternative_formats', 'Alternative Formats'),
         ('digital_out_of_home', 'Digital out-of-home'),
         ('email_signatures', 'Email Signature'),
         ('fact_sheets', 'Fact Sheet'),

--- a/CMS/templates/contentPages/asset_type_page.html
+++ b/CMS/templates/contentPages/asset_type_page.html
@@ -16,28 +16,16 @@
         <div class="crc-tab-content-shelf">
             <div class="container crc-nav-tab-content">
                 <div class="resources-search-panel">
-                    <div class="row">
-                        <div class="col-sm-9 col-xs-7">
-                            <div class="row">
-                                <div class="col-sm-9 col-xs-12">
-                                    <div id="search-results-summary">
-                                        <div class="row">
-                                            <div class="col-xs-12">
-                                                <div class="panel-heading">{{ page.asset_count }} items matching</div>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                            <div id="search-results" class="spacer-top-1">
-                                <div class="row">
-                                    <ul class="crc-thumbnails">
-                                        {% for resource_item_page in page.resource_item_pages  %}
-                                        {% include 'partials/resource_list_item.html' with resource_page=resource_item_page %}
-                                    {% endfor %}
-                                    </ul>
-                                </div>
-                            </div>
+                    <div id="search-results-summary">
+                        <div class="panel-heading">{{ page.asset_count }} items matching</div>
+                    </div>
+                    <div id="search-results" class="spacer-top-1">
+                        <div class="row">
+                            <ul class="crc-thumbnails">
+                                {% for resource_item_page in page.resource_item_pages %}
+                                {% include 'partials/resource_list_item.html' with resource_page=resource_item_page column_width=3 %}
+                                {% endfor %}
+                            </ul>
                         </div>
                     </div>
                 </div>

--- a/CMS/templates/contentPages/resources_page.html
+++ b/CMS/templates/contentPages/resources_page.html
@@ -73,7 +73,7 @@
                             <div class="row">
                                 <div class="crc-thumbnails">
                                     {% for resource_page in page.resource_list %}
-                                        {% include 'partials/resource_list_item.html' with resource_page=resource_page %}
+                                        {% include 'partials/resource_list_item.html' with resource_page=resource_page column_width=4%}
                                     {% endfor %}
                                 </div>
                             </div>

--- a/CMS/templates/partials/resource_list_item.html
+++ b/CMS/templates/partials/resource_list_item.html
@@ -3,7 +3,7 @@
 {% image resource_page.preview_image original as preview_image %}
 {% convert_s3_link preview_image.url as preview_image_url %}
 
-<div class="resource-card col-sm-6 col-md-4">
+<div class="resource-card col-sm-6 col-md-{{ column_width }}">
     <a class="resource-card__thumbnail-container" href="{% if resource_page %}{% pageurl resource_page %}{% endif %}">
         <div class="resource-card__thumbnail">
             <div class="resource-card__image-wrapper"

--- a/CMS/templates/partials/resource_list_item.html
+++ b/CMS/templates/partials/resource_list_item.html
@@ -16,7 +16,7 @@
                 <div class="resource-card__title-container">
                     <h3 class="resource-card__title"
                         title="{{ resource_page.title }}">{{ resource_page.title }}</h3>
-                    <p class="resource-card__detail" title="Coronavirus (COVID-19)">{{ page.site_heading }}</p>
+                    <p class="resource-card__detail" title="Coronavirus (COVID-19)">{{ resource_page.campaign_name }}</p>
                 </div>
                 <span class="resource-card__download-caption">Downloadable</span>
             </div>

--- a/CMS/templates/partials/resource_list_item.html
+++ b/CMS/templates/partials/resource_list_item.html
@@ -16,8 +16,7 @@
                 <div class="resource-card__title-container">
                     <h3 class="resource-card__title"
                         title="{{ resource_page.title }}">{{ resource_page.title }}</h3>
-                    <p class="resource-card__detail" title="Coronavirus (COVID-19)">Coronavirus
-                        (COVID-19)</p>
+                    <p class="resource-card__detail" title="Coronavirus (COVID-19)">{{ page.site_heading }}</p>
                 </div>
                 <span class="resource-card__download-caption">Downloadable</span>
             </div>

--- a/contentPages/models.py
+++ b/contentPages/models.py
@@ -284,7 +284,7 @@ class ResourceItemPage(MethodsBasePage):
         verbose_name='Upload document'
     )
 
-    document_type = models.CharField(max_length=25, choices=enums.asset_types, default='posters')
+    document_type = models.CharField(max_length=25, choices=enums.asset_types, blank=False)
 
     upload_link = TextField(blank=True, default='')
 
@@ -339,7 +339,7 @@ class SharedContent(models.Model):
 
 
 class AllResourcesTile(Orderable):
-    caption = models.CharField(max_length=25, choices=enums.asset_types, default='')
+    caption = models.CharField(max_length=25, choices=enums.asset_types, blank=False)
     thumbnail_image = models.ForeignKey(
         'wagtailimages.Image',
         null=True,
@@ -418,7 +418,7 @@ class AssetTypePage(MethodsBasePage):
     ASSET_TYPE_HEADER = 'Type Resources'
     signup_intro = TextField(blank=True)
     asset_type_header = TextField(default=ASSET_TYPE_HEADER)
-    document_type = models.CharField(max_length=25, choices=enums.asset_types, default='posters')
+    document_type = models.CharField(max_length=25, choices=enums.asset_types, blank=False)
 
     content_panels = MethodsBasePage.content_panels + [
         FieldPanel('heading'),

--- a/contentPages/models.py
+++ b/contentPages/models.py
@@ -316,6 +316,11 @@ class ResourceItemPage(MethodsBasePage):
     def link_url(self):
         return settings.FINAL_SITE_DOMAIN + self.url
 
+    @property
+    def campaign_name(self):
+        grandparent = self.get_parent().get_parent()
+        return grandparent.landingpage.heading
+
 
 @register_snippet
 class SharedContent(models.Model):

--- a/contentPages/models.py
+++ b/contentPages/models.py
@@ -319,7 +319,7 @@ class ResourceItemPage(MethodsBasePage):
     @property
     def campaign_name(self):
         grandparent = self.get_parent().get_parent()
-        return grandparent.landingpage.heading
+        return grandparent.specific.heading
 
 
 @register_snippet


### PR DESCRIPTION
### What

Added 's' to Web banner, Digital Screen, Alternative Format, Poster. Removed 'poster' as default for asset types. Added the campaign name to resource item cards. 

