### PR TITLE
Feature/add h2 headings on subscribe and category pages

### DIFF
--- a/CMS/static/scss/crc.scss
+++ b/CMS/static/scss/crc.scss
@@ -28,11 +28,6 @@ TODO: Only used in one place - may be artifact
 /*
 SHELVES ARE USED THROUGHOUT CV19 CODE
 */
-.shelf h2 {
-  font-size: 2em;
-  text-align: center;
-  color: #555
-}
 
 .shelf .intro p {
   text-align: center
@@ -54,12 +49,6 @@ SHELVES ARE USED THROUGHOUT CV19 CODE
 
 .crc-tab-content-shelf {
   background-color: #f5f5f5
-}
-
-.crc-tab-content-shelf h2 {
-  font-size: 2em;
-  text-align: center;
-  color: #555
 }
 
 .crc-tab-content-shelf .intro p {

--- a/CMS/static/scss/global.scss
+++ b/CMS/static/scss/global.scss
@@ -283,3 +283,36 @@ a.skip-main {
         font-weight: bold;
     }
 }
+
+.shelf h2 {
+  font-size: 2em;
+  text-align: center;
+  color: #555
+}
+
+.shelf .campaign-item__caption {
+  padding: 12px 12px;
+    font-size: 19px;
+    background-color: $white;
+    color: $phe-link-color;
+    position: absolute;
+    top: 0;
+    left: 0;
+    border: $phe-link-color 1px solid;
+    z-index: 10;
+}
+
+.crc-tab-content-shelf h2 {
+  font-size: 2em;
+  text-align: center;
+  color: #555
+}
+
+#resources-page-card-title {
+    display: inline;
+    color: $black;
+    padding: 0;
+    font-size: 0.9em;
+    text-align: center;
+    margin: 0px;
+}

--- a/CMS/templates/base.html
+++ b/CMS/templates/base.html
@@ -20,8 +20,8 @@
     <meta http-equiv="Cache-Control" content="no-cache"/>
     <meta http-equiv="Expires" content="0"/>
     <meta http-equiv="Pragma" content="no-cache"/>
-    <link href="{% sass_src 'scss/global.scss' %}" rel="stylesheet" type="text/css">
     <link href="{% sass_src 'scss/crc.scss' %}" rel="stylesheet" type="text/css">
+    <link href="{% sass_src 'scss/global.scss' %}" rel="stylesheet" type="text/css">
     {% block extra_css %}
       {# Override this in templates to add extra stylesheets #}
     {% endblock %}

--- a/CMS/templates/contentPages/all_resources_page.html
+++ b/CMS/templates/contentPages/all_resources_page.html
@@ -24,7 +24,7 @@
 
         <div class="shelf departments">
             <div class="container">
-                <h2>Resources</h2>
+                <h1>Resources</h1>
                 <div class="spacer-top-2">
                     {% for asset_type in page.asset_types.all %}
 
@@ -36,7 +36,7 @@
                                 <a class="campaign-item__link-area"
                                     style="background-image: url({{ thumbnail_url }})"
                                     href="{% pageurl asset_type_page %}">
-                                    <h3 class="campaign-item__caption">{{ asset_type.caption }}</h3>
+                                    <h2 class="campaign-item__caption">{{ asset_type.caption }}</h2>
                                     <div class="campaign-item__arrow"></div>
                                     <div class="overlay"></div>
                                 </a>

--- a/CMS/templates/contentPages/asset_type_page.html
+++ b/CMS/templates/contentPages/asset_type_page.html
@@ -23,6 +23,7 @@
 
         <div class="crc-tab-content-shelf">
             <div class="container crc-nav-tab-content">
+                <h1>{{page.title}}</h1>
                 <div class="resources-search-panel">
                     <div class="row">
                         <div id="search-results-summary" class="col-xs-6">
@@ -43,17 +44,17 @@
                                 <div id="internal-resources">
                                     <div id="popular">
                                         {% for resource_page in page.resource_item_pages %}
-                                            {% include 'partials/resource_list_item.html' with resource_page=resource_page column_width=3%}
+                                            {% include 'partials/resource_list_item.html' with resource_page=resource_page column_width=3 header_level='h2'%}
                                         {% endfor %}
                                     </div>
                                     <div id="newest" style="display: none">
                                         {% for resource_item_page in page.ordered_resource_item_pages %}
-                                            {% include 'partials/resource_list_item.html' with resource_page=resource_item_page column_width=3 %}
+                                            {% include 'partials/resource_list_item.html' with resource_page=resource_item_page column_width=3 header_level='h2'%}
                                         {% endfor %}
                                     </div>
                                     <div id="oldest" style="display: none">
                                         {% for resource_item_page in page.ordered_resource_item_pages reversed %}
-                                            {% include 'partials/resource_list_item.html' with resource_page=resource_item_page column_width=3 %}
+                                            {% include 'partials/resource_list_item.html' with resource_page=resource_item_page column_width=3 header_level='h2'%}
                                         {% endfor %}
                                     </div>
                                 </div>

--- a/CMS/templates/partials/resource_list_item.html
+++ b/CMS/templates/partials/resource_list_item.html
@@ -14,8 +14,13 @@
             </div>
             <div class="resource-card__footer">
                 <div class="resource-card__title-container">
+                    {% if header_level %}
+                    <{{header_level}} id="resources-page-card-title"
+                        title="{{ resource_page.title }}">{{ resource_page.title }}</{{header_level}}>
+                    {% else %}
                     <h3 class="resource-card__title"
                         title="{{ resource_page.title }}">{{ resource_page.title }}</h3>
+                    {% endif %}
                     <p class="resource-card__detail" title="Coronavirus (COVID-19)">{{ resource_page.campaign_name }}</p>
                 </div>
                 <span class="resource-card__download-caption">Downloadable</span>

--- a/subscription/templates/subscription/subscription_page.html
+++ b/subscription/templates/subscription/subscription_page.html
@@ -19,7 +19,7 @@
     </div>
   {% else %}
     <form method="POST" action="#" class="subscription-form container">
-      <h3>{{ page.sub_heading }}</h3>
+      <h2>{{ page.sub_heading }}</h2>
       <p>{{ page.intro }}</p>
 
       <p class="subscription-form__required-field">* Required fields</p>


### PR DESCRIPTION
### What

I have ensured the subscription, all resources and resources by type pages all have h1 headings and that any subsequent headings follow in the correct order, whilst retaining the previous stylings.

### How to review

Run the code in development and visit the above pages to view the changes.
