### PR TITLE
Feature/change sort dropdown to buttons

### DIFF
--- a/CMS/static/js/reorder.js
+++ b/CMS/static/js/reorder.js
@@ -8,7 +8,6 @@
 
   ResourceSort.prototype = {
     setup: function() {
-    debugger;
       this.popularResourceList = this.resourcesArea.find('#popular');
       this.newestResourceList = this.resourcesArea.find('#newest');
       this.startWatcherPopularButton();
@@ -41,17 +40,12 @@
   }
 
   function init() {
-//    var sortSelector = $('#order-selector__toggle');
     var popularButton = $('#order-selector__popular-button')
     var newestButton = $('#order-selector__newest-button')
     var sortItems = $('#internal-resources');
-//    if (sortSelector.length > 0 && sortItems.length > 0) {
-//      new ResourceSort(popularButton, newestButton, sortItems);
-//    }
-    if (sortItems.length > 0) {
+    if (popularButton.length > 0 && newestButton.length > 0 && sortItems.length > 0) {
       new ResourceSort(popularButton, newestButton, sortItems);
     }
-
   }
 
   $(document).on('page:load', init);

--- a/CMS/static/js/reorder.js
+++ b/CMS/static/js/reorder.js
@@ -1,49 +1,57 @@
 (function($) {
-  var ResourceSort = function(sortToggle, resourcesArea) {
-    this.sortToggle = sortToggle;
+  var ResourceSort = function(popularButton, newestButton, resourcesArea) {
+    this.popularButton = popularButton;
+    this.newestButton = newestButton;
     this.resourcesArea = resourcesArea;
     this.setup();
   }
 
   ResourceSort.prototype = {
     setup: function() {
-      this.sortToggle.parent().show();
+    debugger;
       this.popularResourceList = this.resourcesArea.find('#popular');
       this.newestResourceList = this.resourcesArea.find('#newest');
-      this.oldestResourceList = this.resourcesArea.find('#oldest');
-      this.startWatcher();
+      this.startWatcherPopularButton();
+      this.startWatcherNewestButton();
     },
 
-    startWatcher: function() {
+    startWatcherPopularButton: function() {
       var that = this;
-      this.sortToggle.change(function () {
-        that.handleReorder();
+      this.popularButton.click(function () {
+        that.handleReorder('popular')
       })
     },
 
-    handleReorder: function() {
-      if (this.sortToggle[0].value === 'popular') {
+    startWatcherNewestButton: function() {
+      var that = this;
+      this.newestButton.click(function () {
+        that.handleReorder('newest')
+      })
+    },
+
+    handleReorder: function(sortType) {
+      if (sortType === 'popular') {
         this.newestResourceList.hide();
-        this.oldestResourceList.hide();
         this.popularResourceList.show();
-      } else if (this.sortToggle[0].value === 'newest') {
+      } else if (sortType === 'newest') {
         this.popularResourceList.hide();
-        this.oldestResourceList.hide();
         this.newestResourceList.show();
-      } else if (this.sortToggle[0].value === 'oldest') {
-        this.popularResourceList.hide();
-        this.newestResourceList.hide();
-        this.oldestResourceList.show();
       }
     }
   }
 
   function init() {
-    var sortSelector = $('#order-selector__toggle');
+//    var sortSelector = $('#order-selector__toggle');
+    var popularButton = $('#order-selector__popular-button')
+    var newestButton = $('#order-selector__newest-button')
     var sortItems = $('#internal-resources');
-    if (sortSelector.length > 0 && sortItems.length > 0) {
-      new ResourceSort(sortSelector, sortItems);
+//    if (sortSelector.length > 0 && sortItems.length > 0) {
+//      new ResourceSort(popularButton, newestButton, sortItems);
+//    }
+    if (sortItems.length > 0) {
+      new ResourceSort(popularButton, newestButton, sortItems);
     }
+
   }
 
   $(document).on('page:load', init);

--- a/CMS/static/scss/global.scss
+++ b/CMS/static/scss/global.scss
@@ -316,3 +316,9 @@ a.skip-main {
     text-align: center;
     margin: 0px;
 }
+
+.resources-sort {
+   display: flex;
+   align-items:center;
+   min-width: 320px;
+}

--- a/CMS/static/scss/reorder.scss
+++ b/CMS/static/scss/reorder.scss
@@ -1,10 +1,21 @@
-.order-selector {
-  text-align: right;
-  display: none;
-}
 
 #internal-resources {
   #newest, #oldest {
     display: none;
   }
+}
+
+.sort-button {
+  &:focus,
+  &:hover,
+  &:active {
+    background-color: #292929;
+    outline: none;
+  }
+  color: #FFFFFF;
+  background-color: #04857A;
+  border-radius: 7px;
+  margin: 10px;
+  padding: 5px 16px !important;
+  font-size: 16px
 }

--- a/CMS/static/scss/reorder.scss
+++ b/CMS/static/scss/reorder.scss
@@ -10,12 +10,14 @@
   &:hover,
   &:active {
     background-color: #292929;
-    outline: none;
+  }
+  &:focus {
+    text-decoration: underline;
   }
   color: #FFFFFF;
   background-color: #04857A;
   border-radius: 7px;
-  margin: 10px;
-  padding: 5px 16px !important;
+  margin: 5px;
+  padding: 5px 8px !important;
   font-size: 16px
 }

--- a/CMS/static/scss/reorder.scss
+++ b/CMS/static/scss/reorder.scss
@@ -1,6 +1,6 @@
 
 #internal-resources {
-  #newest, #oldest {
+  #newest {
     display: none;
   }
 }

--- a/CMS/templates/contentPages/asset_type_page.html
+++ b/CMS/templates/contentPages/asset_type_page.html
@@ -19,8 +19,6 @@
         <div class="row">
             {% include 'partials/breadcrumbs.html' with ancestors=page.breadcrumbs title=page.title %}
         </div>
-
-
         <div class="crc-tab-content-shelf">
             <div class="container crc-nav-tab-content">
                 <h1>{{page.title}}</h1>
@@ -29,14 +27,11 @@
                         <div id="search-results-summary" class="col-xs-6">
                             <div class="panel-heading">{{ page.asset_count }} items matching</div>
                         </div>
-                        <div class="col-xs-6 order-selector" style="display: none">
-                            Sort by
-                            <select id="order-selector__toggle">
-                              <option value="popular">Most popular first</option>
-                              <option value="newest">Newest first</option>
-                              <option value="oldest">Oldest first</option>
-                            </select>
-                        </div>
+                                <div class="col-xs-6">
+                                    Sort by
+                                    <button id="order-selector__popular-button">Popular</button>
+                                    <button id="order-selector__newest-button">Newest</button>
+                                </div>
                     </div>
                     <div id="search-results" class="spacer-top-1">
                         <div class="row">

--- a/CMS/templates/contentPages/asset_type_page.html
+++ b/CMS/templates/contentPages/asset_type_page.html
@@ -29,10 +29,9 @@
                         </div>
                                 <div class="col-xs-6">
                                     Sort by
-                                    <button id="order-selector__popular-button">Popular</button>
-                                    <button id="order-selector__newest-button">Newest</button>
+                                    <button class="sort-button" id="order-selector__popular-button">Popular</button>
+                                    <button class="sort-button" id="order-selector__newest-button">Newest</button>
                                 </div>
-                    </div>
                     <div id="search-results" class="spacer-top-1">
                         <div class="row">
                             <ul class="crc-thumbnails">

--- a/CMS/templates/contentPages/asset_type_page.html
+++ b/CMS/templates/contentPages/asset_type_page.html
@@ -47,11 +47,6 @@
                                             {% include 'partials/resource_list_item.html' with resource_page=resource_item_page column_width=3 header_level='h2'%}
                                         {% endfor %}
                                     </div>
-                                    <div id="oldest" style="display: none">
-                                        {% for resource_item_page in page.ordered_resource_item_pages reversed %}
-                                            {% include 'partials/resource_list_item.html' with resource_page=resource_item_page column_width=3 header_level='h2'%}
-                                        {% endfor %}
-                                    </div>
                                 </div>
                             </ul>
                         </div>

--- a/CMS/templates/contentPages/asset_type_page.html
+++ b/CMS/templates/contentPages/asset_type_page.html
@@ -24,14 +24,15 @@
                 <h1>{{page.title}}</h1>
                 <div class="resources-search-panel">
                     <div class="row">
-                        <div id="search-results-summary" class="col-xs-6">
+                        <div id="search-results-summary" class="col-sm-6">
                             <div class="panel-heading">{{ page.asset_count }} items matching</div>
                         </div>
-                                <div class="col-xs-6">
-                                    Sort by
-                                    <button class="sort-button" id="order-selector__popular-button">Popular</button>
+                                <div class="col-sm-6">
+                                    Sort by:
+                                    <button class="sort-button" id="order-selector__popular-button">Most popular</button>
                                     <button class="sort-button" id="order-selector__newest-button">Newest</button>
                                 </div>
+                    </div>
                     <div id="search-results" class="spacer-top-1">
                         <div class="row">
                             <ul class="crc-thumbnails">
@@ -55,7 +56,7 @@
                             </ul>
                         </div>
                     </div>
-                </div>
+
             </div>
         </div>
     </div>

--- a/CMS/templates/contentPages/resources_page.html
+++ b/CMS/templates/contentPages/resources_page.html
@@ -74,13 +74,10 @@
                                 <div class="col-xs-6">
                                     <div class="panel-heading">{{ page.resource_count }} items matching</div>
                                 </div>
-                                <div class="col-xs-6 order-selector" style="display: none">
+                                <div class="col-xs-6">
                                     Sort by
-                                    <select id="order-selector__toggle">
-                                      <option value="popular">Most popular first</option>
-                                      <option value="newest">Newest first</option>
-                                      <option value="oldest">Oldest first</option>
-                                    </select>
+                                    <button id="order-selector__popular-button">Popular</button>
+                                    <button id="order-selector__newest-button">Newest</button>
                                 </div>
                             </div>
                         </div>
@@ -96,11 +93,6 @@
                                       </div>
                                       <div id="newest" style="display: none">
                                           {% for resource_page in page.ordered_resource_list %}
-                                              {% include 'partials/resource_list_item.html' with resource_page=resource_page column_width=4%}
-                                          {% endfor %}
-                                      </div>
-                                      <div id="oldest" style="display: none">
-                                          {% for resource_page in page.ordered_resource_list reversed %}
                                               {% include 'partials/resource_list_item.html' with resource_page=resource_page column_width=4%}
                                           {% endfor %}
                                       </div>

--- a/CMS/templates/contentPages/resources_page.html
+++ b/CMS/templates/contentPages/resources_page.html
@@ -71,13 +71,15 @@
                     <div class='col-sm-9 col-xs-7'>
                         <div id="search-results-summary">
                             <div class="row">
-                                <div class="col-xs-6">
+                                <div class="col-sm-6">
                                     <div class="panel-heading">{{ page.resource_count }} items matching</div>
                                 </div>
-                                <div class="col-xs-6">
-                                    Sort by
-                                    <button class="sort-button" id="order-selector__popular-button">Popular</button>
+                                <div class="col-sm-6 resources-sort">
+                                    Sort by:
+                                    <div class="button-container">
+                                    <button class="sort-button" id="order-selector__popular-button">Most popular</button>
                                     <button class="sort-button" id="order-selector__newest-button">Newest</button>
+                                        </div>
                                 </div>
                             </div>
                         </div>

--- a/CMS/templates/contentPages/resources_page.html
+++ b/CMS/templates/contentPages/resources_page.html
@@ -76,8 +76,8 @@
                                 </div>
                                 <div class="col-xs-6">
                                     Sort by
-                                    <button id="order-selector__popular-button">Popular</button>
-                                    <button id="order-selector__newest-button">Newest</button>
+                                    <button class="sort-button" id="order-selector__popular-button">Popular</button>
+                                    <button class="sort-button" id="order-selector__newest-button">Newest</button>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
### What

I have changed the dropdown menu on the "resources by type" and "resources by campaign" pages to buttons, as requested by PHE.  This has involved modifying the reorder functionality in reorder.js as well as adding HTML and stylings for the buttons.  I have also removed all code related to to the "oldest" sort ordering.

### How to review

Run the code in development and visit the two pages to see the changes.
