### PR TITLE
Feature/improves contrast on resource table

### DIFF
--- a/CMS/static/js/main.js
+++ b/CMS/static/js/main.js
@@ -64,6 +64,7 @@
       this.alreadySignedUpMessage = this.form.find('.subscription-form__already');
       this.errorList = this.form.find('.error-list');
       this.errorTitle = this.form.find('.error-title')
+      this.errorContainer = this.form.find('.error-container')
       this.errors = {};
       this.startWatcher();
     },
@@ -87,6 +88,7 @@
       this.alreadySignedUpMessage.hide();
       this.errorList.empty();
       this.errorTitle.text('');
+      this.errorContainer.hide();
     },
 
     startWatcher: function() {
@@ -171,31 +173,32 @@
 
     showErrors: function() {
       if (this.errors) {
-        this.errorTitle.text('There is a problem')
+        this.errorContainer.show().css('display', 'inline-block');
+        this.errorTitle.text('There is a problem');
       }
       if (this.errors.firstName) {
         this.firstNameErrorSpace.text(this.errors.firstName);
         this.firstNameErrorSpace.show();
         this.firstNameErrorSpace.parent().addClass('error');
-        this.errorList.append('<li>' + this.errors.firstName + '</li>');
+        this.errorList.append('<li><a href="#firstname">' + this.errors.firstName + '</a></li>');
       }
       if (this.errors.lastName) {
         this.lastNameErrorSpace.text(this.errors.lastName);
         this.lastNameErrorSpace.show();
         this.lastNameErrorSpace.parent().addClass('error');
-        this.errorList.append('<li>' + this.errors.lastName + '</li>');
+        this.errorList.append('<li><a href="#lastname">' + this.errors.lastName + '</a></li>');
       }
       if (this.errors.email) {
         this.emailErrorSpace.text(this.errors.email);
         this.emailErrorSpace.show();
         this.emailErrorSpace.parent().addClass('error');
-        this.errorList.append('<li>' + this.errors.email + '</li>');
+        this.errorList.append('<li><a href="#email">' + this.errors.email + '</a></li>');
       }
       if (this.errors.terms) {
         this.termsErrorSpace.text(this.errors.terms);
         this.termsErrorSpace.show();
         this.termsErrorSpace.parent().addClass('error');
-        this.errorList.append('<li>' + this.errors.terms + '</li>');
+        this.errorList.append('<li><a href="#terms">' + this.errors.terms + '</a></li>');
       }
     }
   }

--- a/CMS/static/js/main.js
+++ b/CMS/static/js/main.js
@@ -62,6 +62,8 @@
       this.signUpSuccessMessage = this.form.find('.subscription-form__success');
       this.signUpFailMessage = this.form.find('.subscription-form__fail');
       this.alreadySignedUpMessage = this.form.find('.subscription-form__already');
+      this.errorList = this.form.find('.error-list');
+      this.errorTitle = this.form.find('.error-title')
       this.errors = {};
       this.startWatcher();
     },
@@ -83,6 +85,8 @@
       this.signUpFailMessage.hide();
       this.signUpSuccessMessage.hide();
       this.alreadySignedUpMessage.hide();
+      this.errorList.empty();
+      this.errorTitle.text('');
     },
 
     startWatcher: function() {
@@ -166,25 +170,32 @@
     },
 
     showErrors: function() {
+      if (this.errors) {
+        this.errorTitle.text('There is a problem')
+      }
       if (this.errors.firstName) {
         this.firstNameErrorSpace.text(this.errors.firstName);
         this.firstNameErrorSpace.show();
         this.firstNameErrorSpace.parent().addClass('error');
+        this.errorList.append('<li>' + this.errors.firstName + '</li>');
       }
       if (this.errors.lastName) {
         this.lastNameErrorSpace.text(this.errors.lastName);
         this.lastNameErrorSpace.show();
         this.lastNameErrorSpace.parent().addClass('error');
+        this.errorList.append('<li>' + this.errors.lastName + '</li>');
       }
       if (this.errors.email) {
         this.emailErrorSpace.text(this.errors.email);
         this.emailErrorSpace.show();
         this.emailErrorSpace.parent().addClass('error');
+        this.errorList.append('<li>' + this.errors.email + '</li>');
       }
       if (this.errors.terms) {
         this.termsErrorSpace.text(this.errors.terms);
         this.termsErrorSpace.show();
         this.termsErrorSpace.parent().addClass('error');
+        this.errorList.append('<li>' + this.errors.terms + '</li>');
       }
     }
   }

--- a/CMS/static/scss/crc.scss
+++ b/CMS/static/scss/crc.scss
@@ -9167,7 +9167,8 @@ ul.evenly-spaced li {
 .crc-table-striped-heading {
   color: #04867B;
   text-transform: uppercase;
-  width: 25%
+  width: 25%;
+  font-weight: bold;
 }
 
 .icn-restricted {

--- a/CMS/static/scss/subscription.scss
+++ b/CMS/static/scss/subscription.scss
@@ -92,6 +92,12 @@
   }
 }
 
+.error-title {
+    border-left: 5px solid #d4351c;
+    padding: 10px;
+    font-weight: bold;
+}
+
 .service_pending_container {
   margin: 1.5em 0;
 }

--- a/CMS/static/scss/subscription.scss
+++ b/CMS/static/scss/subscription.scss
@@ -23,7 +23,7 @@
     }
 
     &.error {
-      border-left: 2px solid #d4351c;
+      border-left: 3px solid #d4351c;
     }
   }
 
@@ -93,11 +93,26 @@
 }
 
 .error-title {
-    border-left: 5px solid #d4351c;
-    padding: 10px;
+    padding: 10px 10px 0px 10px;
     font-weight: bold;
+    font-size: 1.2em;
 }
 
 .service_pending_container {
   margin: 1.5em 0;
+}
+
+.error-container {
+    display:none;
+    border: 4px solid #d4351c;
+    margin-bottom: 10px;
+}
+
+#errorList a {
+  margin-top: 8px;
+  padding: 0px 12px;
+  list-style: none;
+  color: #d4351c;
+  font-size: 0.9em;
+  text-decoration: underline;
 }

--- a/CMS/templates/partials/resource_list_item.html
+++ b/CMS/templates/partials/resource_list_item.html
@@ -21,7 +21,7 @@
                     <h3 class="resource-card__title"
                         title="{{ resource_page.title }}">{{ resource_page.title }}</h3>
                     {% endif %}
-                    <p class="resource-card__detail" title="Coronavirus (COVID-19)">{{ resource_page.campaign_name }}</p>
+                    <p class="resource-card__detail" title="{{ resource_page.campaign_name }}">{{ resource_page.campaign_name }}</p>
                 </div>
                 <span class="resource-card__download-caption">Downloadable</span>
             </div>

--- a/subscription/templates/subscription/subscription_page.html
+++ b/subscription/templates/subscription/subscription_page.html
@@ -18,7 +18,7 @@
       </div>
     </div>
   {% else %}
-    <form method="POST" action="#" class="subscription-form container">
+    <form method="POST" action="#" class="subscription-form container" aria-live="polite">
       <h2>{{ page.sub_heading }}</h2>
       <p>{{ page.intro }}</p>
 
@@ -29,6 +29,12 @@
       <p class="subscription-form__already">This email address has already signed up for automated updates</p>
 
       <p class="subscription-form__fail">Sign up failed. Please try again</p>
+
+      <div>
+        <p class="error-title"></p>
+        <ul class="error-list">
+        </ul>
+      </div>
 
       <div class="row">
         <div class="subscription-form__field col-sm-12 col-md-6">

--- a/subscription/templates/subscription/subscription_page.html
+++ b/subscription/templates/subscription/subscription_page.html
@@ -23,6 +23,7 @@
       <p>{{ page.intro }}</p>
 
       <div class="error-container" id="errorList" role="alert">
+        <span class="visibly-hidden">Error</span>
         <p class="error-title"></p>
         <ul class="error-list">
         </ul>

--- a/subscription/templates/subscription/subscription_page.html
+++ b/subscription/templates/subscription/subscription_page.html
@@ -30,7 +30,7 @@
 
       <p class="subscription-form__fail">Sign up failed. Please try again</p>
 
-      <div>
+      <div class="error-container">
         <p class="error-title"></p>
         <ul class="error-list">
         </ul>

--- a/subscription/templates/subscription/subscription_page.html
+++ b/subscription/templates/subscription/subscription_page.html
@@ -22,6 +22,12 @@
       <h2>{{ page.sub_heading }}</h2>
       <p>{{ page.intro }}</p>
 
+      <div class="error-container" id="errorList">
+        <p class="error-title"></p>
+        <ul class="error-list">
+        </ul>
+      </div>
+
       <p class="subscription-form__required-field">* Required fields</p>
 
       <p class="subscription-form__success">You have successfully been signed up for automated updates</p>
@@ -30,11 +36,6 @@
 
       <p class="subscription-form__fail">Sign up failed. Please try again</p>
 
-      <div class="error-container">
-        <p class="error-title"></p>
-        <ul class="error-list">
-        </ul>
-      </div>
 
       <div class="row">
         <div class="subscription-form__field col-sm-12 col-md-6">

--- a/subscription/templates/subscription/subscription_page.html
+++ b/subscription/templates/subscription/subscription_page.html
@@ -31,11 +31,11 @@
 
       <p class="subscription-form__required-field">* Required fields</p>
 
-      <p class="subscription-form__success">You have successfully been signed up for automated updates</p>
+      <p class="subscription-form__success" role="alert">You have successfully been signed up for automated updates</p>
 
-      <p class="subscription-form__already">This email address has already signed up for automated updates</p>
+      <p class="subscription-form__already" role="alert">This email address has already signed up for automated updates</p>
 
-      <p class="subscription-form__fail">Sign up failed. Please try again</p>
+      <p class="subscription-form__fail" role="alert">Sign up failed. Please try again</p>
 
 
       <div class="row">

--- a/subscription/templates/subscription/subscription_page.html
+++ b/subscription/templates/subscription/subscription_page.html
@@ -18,11 +18,11 @@
       </div>
     </div>
   {% else %}
-    <form method="POST" action="#" class="subscription-form container" aria-live="polite">
+    <form method="POST" action="#" class="subscription-form container">
       <h2>{{ page.sub_heading }}</h2>
       <p>{{ page.intro }}</p>
 
-      <div class="error-container" id="errorList">
+      <div class="error-container" id="errorList" role="alert">
         <p class="error-title"></p>
         <ul class="error-list">
         </ul>


### PR DESCRIPTION
### What
We have made the heading text on the resource item page table bold to avoid contrast issues.  Text is now 16px and bold.  See screenshots for review.

Before:
<img width="975" alt="Screenshot 2021-05-04 at 11 44 34" src="https://user-images.githubusercontent.com/70749355/116992659-4d984f80-acce-11eb-9cb4-c478b9e10e5a.png">

After:
<img width="941" alt="Screenshot 2021-05-04 at 11 44 50" src="https://user-images.githubusercontent.com/70749355/116992691-56892100-acce-11eb-84e8-f50d8f0689de.png">
