### PR TITLE
improves contrast on link tags across site

### DIFF
--- a/CMS/static/scss/variables.scss
+++ b/CMS/static/scss/variables.scss
@@ -1,7 +1,7 @@
 $black: #000000;
 $white: #FFFFFF;
 
-$link-blue: #2f25f7;
+$link-blue: #3174AF;
 
 $default-font: Arial;
 $default-font-color: $black;


### PR DESCRIPTION
### What

We have changed the colour of the <a> tags across the site in order to meet the 4.5 : 1 contrast ratio requirement.

Before:
<img width="815" alt="Screenshot 2021-05-04 at 15 46 49" src="https://user-images.githubusercontent.com/70749355/117023138-bc86a000-acf0-11eb-9447-d86532e09429.png">

After:
<img width="816" alt="Screenshot 2021-05-04 at 15 54 46" src="https://user-images.githubusercontent.com/70749355/117023569-2141fa80-acf1-11eb-8fcb-d6c557103427.png">


