### PR TITLE
Set localized TIME_ZONE for Wagtail

### DIFF
--- a/CMS/settings/base.py
+++ b/CMS/settings/base.py
@@ -160,7 +160,7 @@ AUTH_PASSWORD_VALIDATORS = [
 
 LANGUAGE_CODE = 'en-us'
 
-TIME_ZONE = 'UTC'
+TIME_ZONE = 'Europe/London'
 
 USE_I18N = True
 


### PR DESCRIPTION
### What

Wagtail was displaying dates using UTC instead of BST. The logical path is painful but as a result publication is happening an hour later than the time users set in the Wagtail interface.

The Wagtail interface has been set to use `Europe/London` time which adjusts for BST

### How to review

Create a new page and on its Settings tab set the Go live datetime to `5th May 2021 - 11:00` - That is a BST date
Check your database - the `go_live_at` should be set for the equivalent UCT time `2021-05-05 10:00... +00:00`
