### PR TITLE
removes title attribute from div element in resource list item

### DIFF
--- a/CMS/templates/partials/resource_list_item.html
+++ b/CMS/templates/partials/resource_list_item.html
@@ -9,8 +9,7 @@
             <div class="resource-card__image-wrapper"
                  style="background-image: url('/static/img/resource-bg.png')">
                 <div class="asset-thumb-container"
-                     style="background-image: url({{ preview_image_url }})"
-                     title="{{ resource_page.title }}"></div>
+                     style="background-image: url({{ preview_image_url }})"></div>
             </div>
             <div class="resource-card__footer">
                 <div class="resource-card__title-container">


### PR DESCRIPTION
### What

We have removed the title attribute from the resource list item div element, which was causing screen readers to stutter, as well as not corresponding to any visual text content in the div.