### PR TITLE
Feature/remove div elements from lists

### DIFF
--- a/CMS/templates/contentPages/asset_type_page.html
+++ b/CMS/templates/contentPages/asset_type_page.html
@@ -34,22 +34,22 @@
                     </div>
                     <div id="search-results" class="spacer-top-1">
                         <div class="row">
-                                <ul id="internal-resources" class="crc-thumbnails">
-                                    <li id="popular">
+                                <div id="internal-resources" class="crc-thumbnails">
+                                    <div id="popular">
                                         <ul>
                                             {% for resource_page in page.resource_item_pages %}
                                             {% include 'partials/resource_list_item.html' with resource_page=resource_page column_width=3 header_level='h2'%}
                                         {% endfor %}
                                         </ul>
-                                    </li>
-                                    <li id="newest" style="display: none">
+                                    </div>
+                                    <div id="newest" style="display: none">
                                         <ul>
                                             {% for resource_item_page in page.ordered_resource_item_pages %}
                                             {% include 'partials/resource_list_item.html' with resource_page=resource_item_page column_width=3 header_level='h2'%}
                                         {% endfor %}
                                         </ul>
-                                    </li>
-                                </ul>
+                                    </div>
+                                </div>
                         </div>
                     </div>
 

--- a/CMS/templates/contentPages/asset_type_page.html
+++ b/CMS/templates/contentPages/asset_type_page.html
@@ -34,20 +34,22 @@
                     </div>
                     <div id="search-results" class="spacer-top-1">
                         <div class="row">
-                            <ul class="crc-thumbnails">
-                                <div id="internal-resources">
-                                    <div id="popular">
-                                        {% for resource_page in page.resource_item_pages %}
+                                <ul id="internal-resources" class="crc-thumbnails">
+                                    <li id="popular">
+                                        <ul>
+                                            {% for resource_page in page.resource_item_pages %}
                                             {% include 'partials/resource_list_item.html' with resource_page=resource_page column_width=3 header_level='h2'%}
                                         {% endfor %}
-                                    </div>
-                                    <div id="newest" style="display: none">
-                                        {% for resource_item_page in page.ordered_resource_item_pages %}
+                                        </ul>
+                                    </li>
+                                    <li id="newest" style="display: none">
+                                        <ul>
+                                            {% for resource_item_page in page.ordered_resource_item_pages %}
                                             {% include 'partials/resource_list_item.html' with resource_page=resource_item_page column_width=3 header_level='h2'%}
                                         {% endfor %}
-                                    </div>
-                                </div>
-                            </ul>
+                                        </ul>
+                                    </li>
+                                </ul>
                         </div>
                     </div>
 

--- a/CMS/templates/contentPages/resources_page.html
+++ b/CMS/templates/contentPages/resources_page.html
@@ -86,7 +86,6 @@
 
                         <div id="search-results" class="spacer-top-1">
                             <div class="row">
-                                <!-- <div class="crc-thumbnails"> -->
                                     <ul id="internal-resources" class="crc-thumbnails">
                                       <li id="popular">
                                           <ul>
@@ -113,9 +112,6 @@
                                             </ul>
                                         </li>
                                     </ul>
-
-                                    
-                                <!-- </div> -->
                             </div>
                         </div>
                     </div>

--- a/CMS/templates/contentPages/resources_page.html
+++ b/CMS/templates/contentPages/resources_page.html
@@ -86,24 +86,36 @@
 
                         <div id="search-results" class="spacer-top-1">
                             <div class="row">
-                                <div class="crc-thumbnails">
-                                    <div id="internal-resources">
-                                      <div id="popular">
-                                          {% for resource_page in page.resource_list %}
+                                <!-- <div class="crc-thumbnails"> -->
+                                    <ul id="internal-resources" class="crc-thumbnails">
+                                      <li id="popular">
+                                          <ul>
+                                            {% for resource_page in page.resource_list %}
+                                            {% include 'partials/resource_list_item.html' with resource_page=resource_page column_width=4%}
+                                        {% endfor %}
+                                          </ul>
+                                          
+                                      </li>
+                                      <li id="newest" style="display: none">
+                                        <ul>
+                                            {% for resource_page in page.ordered_resource_list %}
                                               {% include 'partials/resource_list_item.html' with resource_page=resource_page column_width=4%}
                                           {% endfor %}
-                                      </div>
-                                      <div id="newest" style="display: none">
-                                          {% for resource_page in page.ordered_resource_list %}
-                                              {% include 'partials/resource_list_item.html' with resource_page=resource_page column_width=4%}
-                                          {% endfor %}
-                                      </div>
-                                    </div>
+                                        </ul> 
+                                      </li>
+                                    </ul>
+                                    <ul class="crc-thumbnails">
+                                        <li>
+                                            <ul>
+                                                {% for external_resource in page.external_resources.all %}
+                                                {% include 'partials/external_resource_item.html' with external_resource=external_resource column_width=4 campaign_name=page.campaign_name%}
+                                            {% endfor %}
+                                            </ul>
+                                        </li>
+                                    </ul>
 
-                                    {% for external_resource in page.external_resources.all %}
-                                        {% include 'partials/external_resource_item.html' with external_resource=external_resource column_width=4 campaign_name=page.campaign_name%}
-                                    {% endfor %}
-                                </div>
+                                    
+                                <!-- </div> -->
                             </div>
                         </div>
                     </div>

--- a/CMS/templates/contentPages/resources_page.html
+++ b/CMS/templates/contentPages/resources_page.html
@@ -86,32 +86,30 @@
 
                         <div id="search-results" class="spacer-top-1">
                             <div class="row">
-                                    <ul id="internal-resources" class="crc-thumbnails">
-                                      <li id="popular">
+                                    <div id="internal-resources" class="crc-thumbnails">
+                                      <div id="popular">
                                           <ul>
                                             {% for resource_page in page.resource_list %}
                                             {% include 'partials/resource_list_item.html' with resource_page=resource_page column_width=4%}
                                         {% endfor %}
                                           </ul>
                                           
-                                      </li>
-                                      <li id="newest" style="display: none">
+                                      </div>
+                                      <div id="newest" style="display: none">
                                         <ul>
                                             {% for resource_page in page.ordered_resource_list %}
                                               {% include 'partials/resource_list_item.html' with resource_page=resource_page column_width=4%}
                                           {% endfor %}
                                         </ul> 
-                                      </li>
-                                    </ul>
-                                    <ul class="crc-thumbnails">
-                                        <li>
+                                      </div>
+                                    </div>
+                                    <div class="crc-thumbnails">
                                             <ul>
                                                 {% for external_resource in page.external_resources.all %}
                                                 {% include 'partials/external_resource_item.html' with external_resource=external_resource column_width=4 campaign_name=page.campaign_name%}
                                             {% endfor %}
-                                            </ul>
-                                        </li>
-                                    </ul>
+                                            </ul>   
+                                    </div>
                             </div>
                         </div>
                     </div>

--- a/CMS/templates/partials/external_resource_item.html
+++ b/CMS/templates/partials/external_resource_item.html
@@ -3,7 +3,7 @@
 {% image external_resource.thumbnail_image original as thumbnail_image %}
 {% convert_s3_link thumbnail_image.url as thumbnail_image_url %}
 
-<div class="resource-card col-sm-6 col-md-{{ column_width }}">
+<li class="resource-card col-sm-6 col-md-{{ column_width }}">
     <a class="resource-card__thumbnail-container" href="{{external_resource.external_link}}">
         <div class="resource-card__thumbnail">
             <div class="resource-card__image-wrapper"
@@ -22,4 +22,4 @@
             </div>
         </div>
     </a>
-</div>
+</li>

--- a/CMS/templates/partials/resource_list_item.html
+++ b/CMS/templates/partials/resource_list_item.html
@@ -3,7 +3,7 @@
 {% image resource_page.preview_image original as preview_image %}
 {% convert_s3_link preview_image.url as preview_image_url %}
 
-<div class="resource-card col-sm-6 col-md-{{ column_width }}">
+<li class="resource-card col-sm-6 col-md-{{ column_width }}">
     <a class="resource-card__thumbnail-container" href="{% if resource_page %}{% pageurl resource_page %}{% endif %}">
         <div class="resource-card__thumbnail">
             <div class="resource-card__image-wrapper"
@@ -26,4 +26,4 @@
             </div>
         </div>
     </a>
-</div>
+</li>


### PR DESCRIPTION
### What

We have replaced the div elements with ul and li elements on Resources by Type and Campaign Resources pages.Now we only have li nested inside ul elements.

Note: We have noticed that the sort functionality is not applicable to the external resources. Something that we need to discuss later on.

<img width="1429" alt="Screenshot 2021-05-06 at 14 16 17" src="https://user-images.githubusercontent.com/70764326/117290006-f7661080-ae75-11eb-81a0-559808b0e40d.png">


