### PR TITLE
removes opacity on campaign page tiles

### DIFF
--- a/CMS/static/scss/components/link-block.scss
+++ b/CMS/static/scss/components/link-block.scss
@@ -7,7 +7,7 @@ $focus-border-width: 3px;
   position: relative;
   margin: 2em 1em $focus-border-width;
   height: 221px;
-  background: rgba(0, 0, 0, 0.6);
+  background: $tile-background-color;
   overflow: hidden;
 
   .row {
@@ -17,7 +17,7 @@ $focus-border-width: 3px;
   .title h2 {
     padding: 18px;
     border: 3px solid transparent;
-    background: rgba(0, 0, 0, 0.6);
+    background: $tile-title-background-color;
     color: $white;
     font-size: 36px;
     margin-bottom: 0px;

--- a/CMS/static/scss/variables.scss
+++ b/CMS/static/scss/variables.scss
@@ -32,3 +32,6 @@ $mobile-body-font-size: 16px;
 $mobile-body-line-height: 16px;
 $small-font-size: 14px;
 $small-line-height: 14px;
+
+$tile-background-color: #4D4D4D;
+$tile-title-background-color: #292929;


### PR DESCRIPTION
### What

We have removed the opacity from the tiles on the campaign page, and changed the colour scheme for the title and main tile body using two new colour variables to keep it broadly in line with the rest of the site.

<img width="1169" alt="Screenshot 2021-05-06 at 12 39 53" src="https://user-images.githubusercontent.com/70749355/117292562-460cae00-ae68-11eb-96d3-067b5e0f3832.png">

