### PR TITLE
stops page jumping when sort button is clicked

### DIFF
--- a/CMS/static/js/reorder.js
+++ b/CMS/static/js/reorder.js
@@ -17,14 +17,14 @@
     startWatcherPopularButton: function() {
       var that = this;
       this.popularButton.click(function () {
-        that.handleReorder('popular')
+        that.handleReorder('popular');
       })
     },
 
     startWatcherNewestButton: function() {
       var that = this;
       this.newestButton.click(function () {
-        that.handleReorder('newest')
+        that.handleReorder('newest');
       })
     },
 

--- a/CMS/static/scss/reorder.scss
+++ b/CMS/static/scss/reorder.scss
@@ -1,10 +1,3 @@
-
-#internal-resources {
-  #newest {
-    display: none;
-  }
-}
-
 .sort-button {
   &:focus,
   &:hover,


### PR DESCRIPTION
### What

We have removed part of the sort button styling that was clashing with jquery and causing the page to jump on click.

### How to review

Run the code in development and visit all-resources/posters or a campaign resources page and test the sort buttons.
