### PR TITLE
add no-js functionality

### DIFF
--- a/CMS/static/scss/base/_utilities.scss
+++ b/CMS/static/scss/base/_utilities.scss
@@ -1,0 +1,3 @@
+.no-js .no-js-hidden {
+  display: none !important;
+}

--- a/CMS/static/scss/global.scss
+++ b/CMS/static/scss/global.scss
@@ -1,4 +1,5 @@
 @import "./variables";
+@import "base/utilities";
 @import "components/breadcrumbs";
 @import "components/download-button";
 @import "components/link-block";

--- a/CMS/templates/500.html
+++ b/CMS/templates/500.html
@@ -1,11 +1,12 @@
 <!DOCTYPE html>
-<html class="no-js">
+<html>
     <head>
         <meta charset="utf-8" />
         <title>Internal server error</title>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
     </head>
-    <body>
+    <body class="no-js">
+        {% include 'partials/no-js.html' %}
         <h1>Internal server error</h1>
 
         <h2>Sorry, there seems to be an error. Please try again soon.</h2>

--- a/CMS/templates/base.html
+++ b/CMS/templates/base.html
@@ -1,7 +1,7 @@
 {% load static wagtailuserbar methods_tags sass_tags %}
 
 <!DOCTYPE html>
-<html class="no-js" lang="en">
+<html lang="en">
   <head>
     <meta charset="utf-8"/>
     <title>
@@ -38,7 +38,9 @@
     {% endblock %}
   </head>
 
-  <body class="{% block body_class %}{% endblock %}">
+  <body class="{% block body_class %}{% endblock %} no-js">
+    {% include 'partials/no-js.html' %}
+
     <div class="row">
       <a class="skip-main" href="#main-content">Skip to main content</a>
     </div>

--- a/CMS/templates/contentPages/resources_page.html
+++ b/CMS/templates/contentPages/resources_page.html
@@ -74,7 +74,7 @@
                                 <div class="col-sm-6">
                                     <div class="panel-heading">{{ page.resource_count }} items matching</div>
                                 </div>
-                                <div class="col-sm-6 resources-sort">
+                                <div class="col-sm-6 resources-sort no-js-hidden">
                                     Sort by:
                                     <div class="button-container">
                                     <button class="sort-button" id="order-selector__popular-button">Most popular</button>

--- a/CMS/templates/partials/no-js.html
+++ b/CMS/templates/partials/no-js.html
@@ -1,0 +1,1 @@
+<script>document.body.className = ((document.body.className) ? document.body.className.replace(/\bno-js\b/g, '') : '');</script>

--- a/CMS/templates/search.html
+++ b/CMS/templates/search.html
@@ -1,7 +1,7 @@
 {% load static wagtailuserbar %}
 
 <!DOCTYPE html>
-<html class="no-js" lang="en">
+<html lang="en">
     <head>
         <meta charset="utf-8" />
         <title>
@@ -29,7 +29,8 @@
         <link rel="stylesheet" type="text/css" href="{% static 'css/main.css' %}">
     </head>
 
-    <body class="{% block body_class %}{% endblock %}">
+    <body class="{% block body_class %}{% endblock %} no-js">
+        {% include 'partials/no-js.html' %}
         {% wagtailuserbar %}
         <div class="searchtool-container">
           <button class="back-button" role="button">< back</button>


### PR DESCRIPTION
### What

Government websites often require content to be available when javascript is turned off. This is often done by having a no-js class on a top level tag which will be removed using a simple inline script if javascript is running. If javascript is not running the script doesn't run, the `no-js` class stays, and css can be used to make changes to the site.

PHE already had a `no-js` tag in it's `html` element but it was non-functional. This PR makes that functionality work and uses it to hide features that rely on javascript with the new `no-js-hidden` class

### How to review
This review requires you to switch between javascript on and off. This is hidden somewhere in settings and there are plenty of Chrome extensions like "Quick Javascript Switcher" that can be useful

**With javascript turned on**
Check that `<body>` doesn't have the `no-js` class
View resources page at `/phe/resources/` and verify the sort buttons are present

**With javascript turned off**
Check that `<body>` has the `no-js` class
View resources page at `/phe/resources/` and verify the sort buttons are hidden