### PR TITLE
reverses the transparency changes on the campaign tiles and adds in f…

### DIFF
--- a/CMS/static/scss/components/link-block.scss
+++ b/CMS/static/scss/components/link-block.scss
@@ -7,7 +7,7 @@ $focus-border-width: 3px;
   position: relative;
   margin: 2em 1em $focus-border-width;
   height: 221px;
-  background: $tile-background-color;
+  background: rgba(0, 0, 0, 0.6);
   overflow: hidden;
 
   .row {
@@ -15,12 +15,14 @@ $focus-border-width: 3px;
   }
 
   .title h2 {
+
     padding: 18px;
     border: 3px solid transparent;
-    background: $tile-title-background-color;
+    background: rgba(0, 0, 0, 0.6);
     color: $white;
     font-size: 36px;
     margin-bottom: 0px;
+
   }
 
   .overview {
@@ -35,14 +37,20 @@ $focus-border-width: 3px;
   .phe-links-block__arrow {
     bottom: calc(-2 * #{$focus-border-width});
   }
+  .title h2{
+    background-color: $phe-teal
+  }
 }
 
 .phe-links-block a:focus .block {
   margin: calc(2em - #{$focus-border-width}) calc(1em - #{$focus-border-width}) 0;
   border: $white $focus-border-width solid;
-
+  
   .phe-links-block__arrow {
     bottom: calc(-2 * #{$focus-border-width});
+  }
+  .title h2{
+    background-color: $phe-teal
   }
 }
 

--- a/CMS/static/scss/variables.scss
+++ b/CMS/static/scss/variables.scss
@@ -33,5 +33,3 @@ $mobile-body-line-height: 16px;
 $small-font-size: 14px;
 $small-line-height: 14px;
 
-$tile-background-color: #4D4D4D;
-$tile-title-background-color: #292929;


### PR DESCRIPTION

### What

We have reversed the changes on the transparent campaign tiles and we added a teal background colour on the tile header in focus and hover state.

On focus:

![Screenshot 2021-05-11 at 10 36 32](https://user-images.githubusercontent.com/70764326/117794171-e423be00-b244-11eb-9a03-255a58760b13.png)

On hover:

![Screenshot 2021-05-11 at 10 36 21](https://user-images.githubusercontent.com/70764326/117794203-edad2600-b244-11eb-9024-8ce0515f8186.png)


### How to review

Hover on the campaign tiles and tab through the Campaign Page to see the changes.
