### PR TITLE
allows font size adjustments on the overview and resource tiles without loss of content

### DIFF
--- a/CMS/static/scss/components/link-block.scss
+++ b/CMS/static/scss/components/link-block.scss
@@ -6,10 +6,10 @@ $focus-border-width: 3px;
 .phe-links-block a .block {
   position: relative;
   margin: 2em 1em $focus-border-width;
-  height: 221px;
+  min-height: 221px;
   background: $tile-background-color;
   overflow: hidden;
-
+  
   .row {
     margin: 0 0 -4px
   }

--- a/CMS/static/scss/crc.scss
+++ b/CMS/static/scss/crc.scss
@@ -6435,12 +6435,6 @@ div.right-arrow {
   background-position: 25% 54%
 }
 
-@media (min-width: 992px) {
-  .one-you-links .links-row {
-    height: 300px
-  }
-}
-
 @media (max-width: 992px) {
   .one-you-links .links-row {
     height: 600px

--- a/CMS/static/scss/global.scss
+++ b/CMS/static/scss/global.scss
@@ -323,3 +323,12 @@ a.skip-main {
    align-items:center;
    min-width: 320px;
 }
+
+@media (min-width: 992px) {
+  .one-you-links .links-row {
+    min-height: 300px;
+  }
+}
+.links-row{
+  padding-bottom: 2em;
+}


### PR DESCRIPTION
### What

We have changed the height property to a min-height property of the Overview and Resource tiles on Campaign page to allow the tile text to be resized without cutting off the content. We also added some bottom padding on the background image to keep the same gap at the bottom and top with the tiles border while zooming.

Before:

![Screenshot 2021-05-11 at 17 08 31](https://user-images.githubusercontent.com/70764326/117849786-932fbc00-b27c-11eb-961a-6fdea487b6d2.png)

After:

![Screenshot 2021-05-11 at 17 09 59](https://user-images.githubusercontent.com/70764326/117849551-549a0180-b27c-11eb-8343-d22df62170ec.png)

### How to review

For this review is better to use the Safari browser because you can increase or decrease just the font size of the page and this is what is needed to review the changes.
