### PR TITLE
stops the header to overlap with other elements across the site

### DIFF
--- a/CMS/static/scss/crc.scss
+++ b/CMS/static/scss/crc.scss
@@ -6229,6 +6229,12 @@ div.header-block {
 }
 
 
+@media (min-width: 768px) {
+  div.header-block {
+    width: 515px;
+  }
+}
+
 div .vcenter {
   display: table-cell;
   vertical-align: middle;

--- a/CMS/static/scss/crc.scss
+++ b/CMS/static/scss/crc.scss
@@ -6214,7 +6214,6 @@ form.formtastic .popover {
 
 div.header {
   width: 100%;
-  height: 300px;
   /*background: url(/assets/header_image-bec05193e574528bcf6ca8ed75a31bd97fd74efc833305d2910eba81330a4732.jpg) no-repeat center;*/
   -webkit-background-size: cover;
   -moz-background-size: cover;
@@ -6229,11 +6228,6 @@ div.header-block {
   padding: 1.5em 1.5em 1.5em 1.5em
 }
 
-@media (min-width: 768px) {
-  div.header-block {
-    width: 515px
-  }
-}
 
 div .vcenter {
   display: table-cell;

--- a/CMS/static/scss/global.scss
+++ b/CMS/static/scss/global.scss
@@ -380,12 +380,6 @@ table {
     outline: none;
 }
 
-@media (min-width: 768px) {
-  div.header-block {
-    min-width: 515px;
-  }
-}
-
 div.header{
   min-height: 300px;
   padding-bottom: 1em;

--- a/CMS/static/scss/global.scss
+++ b/CMS/static/scss/global.scss
@@ -380,3 +380,14 @@ table {
     outline: none;
 }
 
+@media (min-width: 768px) {
+  div.header-block {
+    min-width: 515px;
+  }
+}
+
+div.header{
+  min-height: 300px;
+  padding-bottom: 1em;
+  margin-bottom: 1em;
+}


### PR DESCRIPTION
### What

We have updated the header across site so that it adjusts its size when the text is zoomed in without overlapping with other elements.

Before:

![Screenshot 2021-05-12 at 09 41 04](https://user-images.githubusercontent.com/70764326/117946242-0716a680-b307-11eb-9271-458314c11ee1.png)
![Screenshot 2021-05-12 at 09 42 17](https://user-images.githubusercontent.com/70764326/117946256-0aaa2d80-b307-11eb-93d5-ac8e99540b0d.png)

After:

![Screenshot 2021-05-12 at 09 41 32](https://user-images.githubusercontent.com/70764326/117946339-201f5780-b307-11eb-9398-109169544253.png)
![Screenshot 2021-05-12 at 09 42 54](https://user-images.githubusercontent.com/70764326/117946351-2281b180-b307-11eb-9358-10daeee5d224.png)


### How to review

For this review is best to use the Safari browser in order to increase/decrease the font size.
