### PR TITLE
description on tiles renders fully

### DIFF
--- a/CMS/static/scss/global.scss
+++ b/CMS/static/scss/global.scss
@@ -211,6 +211,8 @@ a[target="_blank"] {
     font-size: 12px;
     padding: 5px 0 10px 0;
     text-align: left;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 
   &__download-caption {


### PR DESCRIPTION
### What

We have added the overflow and text-overflow properties on the tile description section to let the user know that the full description is displayed on the next page.

Before:

![Screenshot 2021-05-12 at 14 35 35](https://user-images.githubusercontent.com/70764326/117984058-67b9d980-b32f-11eb-8e77-f99976d43ee5.png)

After:

![Screenshot 2021-05-12 at 14 41 07](https://user-images.githubusercontent.com/70764326/117984920-2a098080-b330-11eb-85d5-5e3923874ccf.png)

### How to review

For this review is best to use the Safari browser in order to increase/decrease the font size.


