### PR TITLE
fixes focus issue when zoomed in

### DIFF
--- a/CMS/static/scss/crc.scss
+++ b/CMS/static/scss/crc.scss
@@ -9572,7 +9572,6 @@ nav.crc-navbar .crc-navbar-center li:last-child {
 
 nav.crc-navbar ul.navbar-nav li a.crc-menu-item {
   font-family: "HelveticaNeueMedium", Helvetica, Arial, sans-serif;
-  height: 74px;
   line-height: 74px;
   padding: 0px 16px;
   margin: 0px;

--- a/CMS/static/scss/global.scss
+++ b/CMS/static/scss/global.scss
@@ -380,3 +380,11 @@ table {
     outline: none;
 }
 
+nav.crc-navbar ul.navbar-nav li a.crc-menu-item {
+  font-family: "HelveticaNeueMedium", Helvetica, Arial, sans-serif;
+  min-height: 74px;
+  line-height: 74px;
+  padding: 0px 16px;
+  margin: 0px;
+  color: #fff
+}


### PR DESCRIPTION
### What

We have slightly modified the navbar stylings to fix a bug where focus states were misaligned when the font was zoomed to 200%.

### How to review

Run the code and visit any page in safari, zoom the font to 200% and tab through the nav bar.
