### PR TITLE
solves the tiles bobbing issue on hover and focus

### DIFF
--- a/CMS/static/scss/components/link-block.scss
+++ b/CMS/static/scss/components/link-block.scss
@@ -5,7 +5,7 @@ $focus-border-width: 3px;
 
 .phe-links-block a .block {
   position: relative;
-  margin: 2em 1em $focus-border-width;
+  margin: 2em 1em 0px;
   height: 221px;
   background: rgba(0, 0, 0, 0.6);
   overflow: hidden;
@@ -31,7 +31,7 @@ $focus-border-width: 3px;
 }
 
 .phe-links-block a:hover .block {
-  margin: calc(2em - #{$focus-border-width}) calc(1em - #{$focus-border-width}) 0;
+  margin: calc(2em - #{$focus-border-width}) calc(1em - #{$focus-border-width}) 3px;
   border: $white $focus-border-width solid;
 
   .phe-links-block__arrow {
@@ -43,7 +43,7 @@ $focus-border-width: 3px;
 }
 
 .phe-links-block a:focus .block {
-  margin: calc(2em - #{$focus-border-width}) calc(1em - #{$focus-border-width}) 0;
+  margin: calc(2em - #{$focus-border-width}) calc(1em - #{$focus-border-width}) 3px;
   border: $white $focus-border-width solid;
   
   .phe-links-block__arrow {
@@ -68,4 +68,8 @@ $focus-border-width: 3px;
   bottom: 0;
   right: 0;
   z-index: 10;
+}
+
+.phe-links-block a:focus{
+  outline: none;
 }

--- a/CMS/static/scss/global.scss
+++ b/CMS/static/scss/global.scss
@@ -380,3 +380,6 @@ table {
     outline: none;
 }
 
+main {
+  outline: none;
+}


### PR DESCRIPTION
### What

We have fixed the jump issue of the tiles when in the hover or focus state (check the comment you left on https://github.com/methods/phe-cv19-site/pull/146 ).
Also we took out the outline that was showing up on Safari by default, when focusing on the <main> and the <a> tag elements on the same page.

The outline when in focus state on <a> and <main> tag elements:

![Screenshot 2021-05-17 at 11 05 41](https://user-images.githubusercontent.com/70764326/118471812-0d8a9100-b700-11eb-8c50-160cf40a679e.png)

![Screenshot 2021-05-17 at 11 04 04](https://user-images.githubusercontent.com/70764326/118471825-11b6ae80-b700-11eb-9713-39bad5058fda.png)

### How to review

Best to run the code in Safari, hover and tab through the page.
