### PR TITLE
fixes tiles bobbing in hover state

### DIFF
--- a/CMS/static/scss/components/link-block.scss
+++ b/CMS/static/scss/components/link-block.scss
@@ -5,7 +5,7 @@ $focus-border-width: 3px;
 
 .phe-links-block a .block {
   position: relative;
-  margin: 2em 1em 0px;
+  margin: 2em 1em 3px;
   min-height: 221px;
   background: rgba(0, 0, 0, 0.6);
   overflow: hidden;
@@ -31,8 +31,8 @@ $focus-border-width: 3px;
 }
 
 .phe-links-block a:hover .block {
-  margin: calc(2em - #{$focus-border-width}) calc(1em - #{$focus-border-width}) 3px;
   border: $white $focus-border-width solid;
+  margin-bottom: -3px;
 
   .phe-links-block__arrow {
     bottom: calc(-2 * #{$focus-border-width});
@@ -42,9 +42,15 @@ $focus-border-width: 3px;
   }
 }
 
+@media (max-width: 991px) {
+    .phe-links-block a:hover .block {
+        margin-bottom: 3px;
+    }
+}
+
 .phe-links-block a:focus .block {
-  margin: calc(2em - #{$focus-border-width}) calc(1em - #{$focus-border-width}) 3px;
   border: $white $focus-border-width solid;
+  margin-bottom: -3px;
   
   .phe-links-block__arrow {
     bottom: calc(-2 * #{$focus-border-width});
@@ -52,6 +58,12 @@ $focus-border-width: 3px;
   .title h2{
     background-color: $phe-teal
   }
+}
+
+@media (max-width: 991px) {
+    .phe-links-block a:focus .block {
+        margin-bottom: 3px;
+    }
 }
 
 .phe-links-block__arrow {


### PR DESCRIPTION
### What

We have added a media query to the hover and focus states for the tiles so that they don't bob about when stacked.  There are still issues with the tiles altering the background image size when in hover state when the overview/resource text is long, but we think this is a marginal case.

### How to review

Run the code and visit the campaign landing page, reduce the window so the tiles are stacked, and hover.
