### PR TITLE
fixes border on tiles to prevent bobbing

### DIFF
--- a/CMS/static/scss/components/link-block.scss
+++ b/CMS/static/scss/components/link-block.scss
@@ -31,12 +31,8 @@ $focus-border-width: 3px;
 }
 
 .phe-links-block a:hover .block {
-  border: $white $focus-border-width solid;
-  margin-bottom: -3px;
+  outline: $white $focus-border-width solid;
 
-  .phe-links-block__arrow {
-    bottom: calc(-2 * #{$focus-border-width});
-  }
   .title h2{
     background-color: $phe-teal
   }
@@ -49,12 +45,8 @@ $focus-border-width: 3px;
 }
 
 .phe-links-block a:focus .block {
-  border: $white $focus-border-width solid;
-  margin-bottom: -3px;
-  
-  .phe-links-block__arrow {
-    bottom: calc(-2 * #{$focus-border-width});
-  }
+  outline: $white $focus-border-width solid;
+
   .title h2{
     background-color: $phe-teal
   }

--- a/CMS/static/scss/crc.scss
+++ b/CMS/static/scss/crc.scss
@@ -6431,7 +6431,7 @@ div.right-arrow {
 
 @media (max-width: 992px) {
   .one-you-links .links-row {
-    height: 600px
+    min-height: 600px
   }
 }
 


### PR DESCRIPTION
### What

We have changed the border on the campaign page tiles to an outline to prevent the text from resizing, which was causing bobbing and resizing of the background image when in a focus/hover state and with a long overview/resource tile description text.

We have also changed the height property of the background image to min-height below 991px so that the image still extends under both tiles.

### How to review

Visit the campaign page, add text to one of the tiles, and focus/hover over the tiles.  Reduce screen width to check the background image is resizing.
