### PR TITLE
specifies psycopg version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Django<2.3,>=2.2.2
 wagtail==2.9.3
 Pillow==6.2.2
-psycopg2-binary
+psycopg2-binary==2.8.6
 flake8==3.7.7
 coverage==4.5.1
 requests==2.21.0


### PR DESCRIPTION
### What

We have specified the version of psycopg being used in requirements.txt to avoid a "database connection isn't set to UTC" error.

### How to review

Navigate to requirements.txt and view the file.  Run the code and check that the above error does not occur.
