### PR TITLE
sets default sort to newest

### DIFF
--- a/CMS/templates/contentPages/asset_type_page.html
+++ b/CMS/templates/contentPages/asset_type_page.html
@@ -28,21 +28,21 @@
                         </div>
                                 <div class="col-sm-6">
                                     Sort by:
-                                    <button class="sort-button sort-button--selected" id="order-selector__popular-button" aria-pressed="true">Most popular</button>
-                                    <button class="sort-button" id="order-selector__newest-button" aria-pressed="false">Newest</button>
+                                    <button class="sort-button sort-button--selected" id="order-selector__newest-button" aria-pressed="true">Newest</button>
+                                    <button class="sort-button" id="order-selector__popular-button" aria-pressed="false">Most popular</button>
                                 </div>
                     </div>
                     <div id="search-results" class="spacer-top-1">
                         <div class="row">
                                 <div id="internal-resources" class="crc-thumbnails">
-                                    <div id="popular">
+                                    <div id="popular" style="display: none">
                                         <ul>
                                             {% for resource_page in page.resource_item_pages %}
                                             {% include 'partials/resource_list_item.html' with resource_page=resource_page column_width=3 header_level='h2'%}
                                         {% endfor %}
                                         </ul>
                                     </div>
-                                    <div id="newest" style="display: none">
+                                    <div id="newest">
                                         <ul>
                                             {% for resource_item_page in page.ordered_resource_item_pages %}
                                             {% include 'partials/resource_list_item.html' with resource_page=resource_item_page column_width=3 header_level='h2'%}

--- a/CMS/templates/contentPages/resources_page.html
+++ b/CMS/templates/contentPages/resources_page.html
@@ -77,8 +77,9 @@
                                 <div class="col-sm-6 resources-sort no-js-hidden">
                                     Sort by:
                                     <div class="button-container">
-                                    <button class="sort-button sort-button--selected" id="order-selector__popular-button" aria-pressed="true">Most popular</button>
-                                    <button class="sort-button" id="order-selector__newest-button" aria-pressed="false">Newest</button>
+                                        <button class="sort-button sort-button--selected" id="order-selector__newest-button" aria-pressed="true">Newest</button>
+                                    <button class="sort-button" id="order-selector__popular-button" aria-pressed="false">Most popular</button>
+
                                         </div>
                                 </div>
                             </div>
@@ -87,7 +88,7 @@
                         <div id="search-results" class="spacer-top-1">
                             <div class="row">
                                     <div id="internal-resources" class="crc-thumbnails">
-                                      <div id="popular">
+                                      <div id="popular" style="display: none">
                                           <ul>
                                             {% for resource_page in page.resource_list %}
                                             {% include 'partials/resource_list_item.html' with resource_page=resource_page column_width=4%}
@@ -95,7 +96,7 @@
                                           </ul>
                                           
                                       </div>
-                                      <div id="newest" style="display: none">
+                                      <div id="newest">
                                         <ul>
                                             {% for resource_page in page.ordered_resource_list %}
                                               {% include 'partials/resource_list_item.html' with resource_page=resource_page column_width=4%}


### PR DESCRIPTION
### What

We have modified the HTML in the resources_page and asset_type_page templates so that the resources are by default ordered newest first, rather than by most popular.  We have also swapped the button positions to reflect this, with the 'Newest' button now appearing on the left.

<img width="1254" alt="Screenshot 2021-07-15 at 15 08 45" src="https://user-images.githubusercontent.com/70749355/125802026-110c7e1b-20db-4b78-9ba4-fafaf1ea8aa6.png">

### How to review

Run the code in development and visit both categories of resource page to check that the sort functionality is working as expected.